### PR TITLE
Bigger and more test matrices, and use `Val` for cache_inclusvity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
 BenchmarkTools = "0.5"
-LoopVectorization = "0.9.13"
+LoopVectorization = "0.9.14"
 VectorizationBase = "0.14.9"
 julia = "1.5"
 

--- a/src/block_sizes.jl
+++ b/src/block_sizes.jl
@@ -53,7 +53,7 @@ function block_sizes(::Type{T}) where {T}
     st = VectorizationBase.static_sizeof(T)
 
     L2 = (StaticInt{_L2}() - StaticInt{_L1}()) ÷ st
-    L3 = _calculate_L3(StaticInt{_L2}(), StaticInt{_L3}(), st, VectorizationBase.CACHE_INCLUSIVITY[3])
+    L3 = _calculate_L3(StaticInt{_L2}(), StaticInt{_L3}(), st, Val{VectorizationBase.CACHE_INCLUSIVITY[3]}())
 
     W = VectorizationBase.pick_vector_width_val(T)
     Mr = StaticInt{LoopVectorization.mᵣ}()
@@ -66,10 +66,6 @@ function block_sizes(::Type{T}) where {T}
     Mc, Kc, Nc
 end
 
-@inline function _calculate_L3(_L2, _L3, st, cache_inclusivity_3::Bool)
-    if cache_inclusivity_3
-        return (_L3 - _L2) ÷ st
-    else
-        return _L3 ÷ st
-    end
-end
+_calculate_L3(_L2, _L3, st, ::Val{true}) = (_L3 - _L2) ÷ st
+_calculate_L3(_L2, _L3, st, ::Val{false}) = _L3 ÷ st
+

--- a/test/block_sizes.jl
+++ b/test/block_sizes.jl
@@ -1,4 +1,4 @@
 @time @testset "block_sizes" begin
-    @test Octavian._calculate_L3(1, 1, 1, true) == 0
-    @test Octavian._calculate_L3(1, 1, 1, false) == 1
+    @test Octavian._calculate_L3(1, 1, 1, Val(true)) == 0
+    @test Octavian._calculate_L3(1, 1, 1, Val(false)) == 1
 end

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -66,13 +66,13 @@ end
 
 @time @testset "Matrix Multiply Int64" begin
     Mc, Kc, Nc = map(Int, Octavian.block_sizes(Int64))
-    for logn ∈ range(log(1), log(2Nc+1), length = 7)
+    for logn ∈ range(log(1), log(1.5Nc+1), length = 7)
         n = round(Int, exp(logn))
-        for logk ∈ range(log(1), log(2Kc+1), length = 7)
+        for logk ∈ range(log(1), log(1.5Kc+1), length = 7)
             k = round(Int, exp(logk))
             B = rand(Int64, k, n)
             B′ = permutedims(B)'
-            for logm ∈ range(log(1), log(2c+1), length = 7)
+            for logm ∈ range(log(1), log(1.5Mc+1), length = 7)
                 m = round(Int, exp(logm))
                 A = rand(Int64, m, k)
                 A′ = permutedims(A)'

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1,12 +1,12 @@
 @time @testset "Matrix Multiply Float32" begin
     Mc, Kc, Nc = map(Int, Octavian.block_sizes(Float32))
-    for logn ∈ range(log(1), log(1.5Nc+1), length = 5)
+    for logn ∈ range(log(1), log(2Nc+1), length = 7)
         n = round(Int, exp(logn))
-        for logk ∈ range(log(1), log(1.5Kc+1), length = 5)
+        for logk ∈ range(log(1), log(2Kc+1), length = 7)
             k = round(Int, exp(logk))
             B = rand(Float32, k, n)
             B′ = permutedims(B)'
-            for logm ∈ range(log(1), log(1.5Mc+1), length = 5)
+            for logm ∈ range(log(1), log(2Mc+1), length = 7)
                 m = round(Int, exp(logm))
                 A = rand(Float32, m, k)
                 A′ = permutedims(A)'
@@ -22,13 +22,13 @@ end
 
 @time @testset "Matrix Multiply Float64" begin
     Mc, Kc, Nc = map(Int, Octavian.block_sizes(Float64))
-    for logn ∈ range(log(1), log(1.5Nc+1), length = 5)
+    for logn ∈ range(log(1), log(2Nc+1), length = 7)
         n = round(Int, exp(logn))
-        for logk ∈ range(log(1), log(1.5Kc+1), length = 5)
+        for logk ∈ range(log(1), log(2Kc+1), length = 7)
             k = round(Int, exp(logk))
             B = rand(Float64, k, n)
             B′ = permutedims(B)'
-            for logm ∈ range(log(1), log(1.5Mc+1), length = 5)
+            for logm ∈ range(log(1), log(2Mc+1), length = 7)
                 m = round(Int, exp(logm))
                 A = rand(Float64, m, k)
                 A′ = permutedims(A)'
@@ -44,13 +44,13 @@ end
 
 @time @testset "Matrix Multiply Int32" begin
     Mc, Kc, Nc = map(Int, Octavian.block_sizes(Int32))
-    for logn ∈ range(log(1), log(1.5Nc+1), length = 5)
+    for logn ∈ range(log(1), log(1.5Nc+1), length = 7)
         n = round(Int, exp(logn))
-        for logk ∈ range(log(1), log(1.5Kc+1), length = 5)
+        for logk ∈ range(log(1), log(1.5Kc+1), length = 7)
             k = round(Int, exp(logk))
             B = rand(Int32, k, n)
             B′ = permutedims(B)'
-            for logm ∈ range(log(1), log(1.5Mc+1), length = 5)
+            for logm ∈ range(log(1), log(1.5Mc+1), length = 7)
                 m = round(Int, exp(logm))
                 A = rand(Int32, m, k)
                 A′ = permutedims(A)'
@@ -66,13 +66,13 @@ end
 
 @time @testset "Matrix Multiply Int64" begin
     Mc, Kc, Nc = map(Int, Octavian.block_sizes(Int64))
-    for logn ∈ range(log(1), log(1.5Nc+1), length = 5)
+    for logn ∈ range(log(1), log(2Nc+1), length = 7)
         n = round(Int, exp(logn))
-        for logk ∈ range(log(1), log(1.5Kc+1), length = 5)
+        for logk ∈ range(log(1), log(2Kc+1), length = 7)
             k = round(Int, exp(logk))
             B = rand(Int64, k, n)
             B′ = permutedims(B)'
-            for logm ∈ range(log(1), log(1.5Mc+1), length = 5)
+            for logm ∈ range(log(1), log(2c+1), length = 7)
                 m = round(Int, exp(logm))
                 A = rand(Int64, m, k)
                 A′ = permutedims(A)'


### PR DESCRIPTION
Fixes #14 

I don't know how extreme you want to go. Maybe be worth trying all numbers along boundaries, at least for `Float64` or `Float32`. The generic matmul fallback is very slow for integers, so we don't really want to test very big sizes there even without code coverage. 