### PR TITLE
Set the random seed at the beginning of the test suite

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,9 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["BenchmarkTools", "InteractiveUtils", "LinearAlgebra", "LoopVectorization", "VectorizationBase", "Test"]
+test = ["BenchmarkTools", "InteractiveUtils", "LinearAlgebra", "LoopVectorization", "Random", "VectorizationBase", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ import BenchmarkTools
 import InteractiveUtils
 import LinearAlgebra
 import LoopVectorization
+import Random
 import Test
 import VectorizationBase
 
@@ -15,6 +16,8 @@ using Test: @testset, @test, @test_throws
 include("test_suite_preamble.jl")
 
 @info("Running Octavian tests with $(Octavian.OCTAVIAN_NUM_TASKS[]) tasks")
+
+Random.seed!(123)
 
 include("block_sizes.jl")
 include("init.jl")


### PR DESCRIPTION
This should help reduce the variability between different CI jobs of the same Julia version.

It probably won't help variability between different Julia versions, as the RNG is allowed to change between minor versions of Julia.