### PR TITLE
Added explicit dependency on ArrayInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,12 @@ authors = ["Mason Protter", "Chris Elrod", "Dilum Aluthge", "contributors"]
 version = "0.1.0-DEV"
 
 [deps]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
-BenchmarkTools = "0.5"
+ArrayInterface = "2.14"
 LoopVectorization = "0.9.14"
 VectorizationBase = "0.14.9"
 julia = "1.5"
@@ -19,8 +20,8 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [targets]
 test = ["BenchmarkTools", "InteractiveUtils", "LinearAlgebra", "LoopVectorization", "Random", "VectorizationBase", "Test"]

--- a/src/Octavian.jl
+++ b/src/Octavian.jl
@@ -1,5 +1,6 @@
 module Octavian
 
+import ArrayInterface
 import LoopVectorization
 import VectorizationBase
 

--- a/test/matmul_coverage.jl
+++ b/test/matmul_coverage.jl
@@ -57,3 +57,19 @@ end
     @test @time(Octavian.matmul(A, B′)) == A * B′
     @test @time(Octavian.matmul(A′, B′)) == A′ * B′
 end
+
+@time @testset "A not-a-StrideArray" begin
+    m = 20
+    n = 20
+    k = 20
+    A = view(rand(Float64, 2m, 2k), 1:2:2m, 2:2:2k)
+    B = rand(Float64, k, n)
+    A′ = view(permutedims(parent(A))', 1:2:2m, 2:2:2k)
+    B′ = permutedims(B)'
+    @show m, k, n
+    @test @time(Octavian.matmul(A, B)) ≈ A * B
+    @test @time(Octavian.matmul(A′, B)) ≈ A′ * B
+    @test @time(Octavian.matmul(A, B′)) ≈ A * B′
+    @test @time(Octavian.matmul(A′, B′)) ≈ A′ * B′
+end
+


### PR DESCRIPTION
BLASBenchmarks currently uses `reshape(view(x, prod(dims)), dims)` to create its arrays.
This is a workaround for a BenchmarkTools issue, where interpolated variables don't get freed by the GC. Doing it that way makes it easier to run benchmarks on computers with limited RAM, because I can use the same `x` across all iterations and matrix sizes (rather than allocating new arrays every time that never get freed).

However, I realized that Octavian was unusually slow at small sizes. This was because
```julia
julia> x = rand(10000);

julia> A = reshape(view(x, 1:16*16), (16,16));

julia> A isa DenseArray
false
```
Because two of Octavian's deps already make heavy use of `ArrayInterface.jl`, I figured the easiest way to handle this case would be to add an explicit dependency. This also opens the door to using it in more places.

A couple asides:
We should really optimize the fast path.
That was important for getting PaddedMatrice's fully dynamic `jmul!(::Matrix, ::Matrix, ::Matrix)` to quickly overtake `StaticArrays`, e.g. [here](https://chriselrod.github.io/PaddedMatrices.jl/dev/arches/cascadelake/#Cascadelake). To hit 20 GFLOPS for 6x6 and 35 for 8x8 requires around 22ns and 30ns respectively; every nanosecond matters there.

Also, we should add threading for loop 5 at smallish sizes, particularly when we don't pack `B`. This is important at smallish sizes, especially on computers with a lot of threads looking for a chunk of matrix to multiply.