### PR TITLE
Stop exporting `matmul` and `matmul!`

### DIFF
--- a/src/Octavian.jl
+++ b/src/Octavian.jl
@@ -6,8 +6,8 @@ import VectorizationBase
 
 using VectorizationBase: StaticInt
 
-export matmul
-export matmul!
+# export matmul
+# export matmul!
 
 include("global_constants.jl")
 include("types.jl")


### PR DESCRIPTION
So that we don't clash with PaddedMatrices, which is going to export `matmul` and `matmul!`.

Eventually, we should rename these functions, and then we can exported the new names.