### PR TITLE
Run CI with one thread and three threads

### DIFF
--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -22,12 +22,11 @@ jobs:
           - x86
         os:
           - ubuntu-latest
-          # - windows-latest
+          # - windows-latest # TODO: uncomment this line
           - macOS-latest
         threads:
           - '1'
-          - '2'
-          # - '64'
+          - '3' # GitHub runners have 2 cores, so `NUM_CORES+1` is 3
         version:
           - 'nightly'
         exclude:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,11 @@ jobs:
           - x86
         os:
           - ubuntu-latest
-          # - windows-latest
+          # - windows-latest # TODO: uncomment this line
           - macOS-latest
         threads:
           - '1'
-          - '2'
-          # - '64'
+          - '3' # GitHub runners have 2 cores, so `NUM_CORES+1` is 3
         version:
           - '1.5'
           - '1' # automatically expands to the latest stable 1.x release of Julia
@@ -68,7 +67,7 @@ jobs:
           - ubuntu-latest
         threads:
           - '1'
-          - '2'
+          - '3' # GitHub runners have 2 cores, so `NUM_CORES+1` is 3
         version:
           - '1' # automatically expands to the latest stable 1.x release of Julia
     steps:


### PR DESCRIPTION
GitHub runners have two cores, so `NUM_CORES+2` is three.

> Each virtual machine has the same hardware resources available.
> - 2-core CPU
> - 7 GB of RAM memory
> - 14 GB of SSD disk space

Source: https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources