### PR TITLE
README: Only mention Tullio.jl and Gaius.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Please see the
 [Octavian documentation](https://JuliaLinearAlgebra.github.io/Octavian.jl/stable).
 
 You may also be interested in:
-- [Tullio.jl](https://github.com/mcabbott/Tullio.jl)
-- [Gaius.jl](https://github.com/MasonProtter/Gaius.jl)
+1. [Tullio.jl](https://github.com/mcabbott/Tullio.jl)
+2. [Gaius.jl](https://github.com/MasonProtter/Gaius.jl)

--- a/README.md
+++ b/README.md
@@ -28,4 +28,3 @@ Please see the
 You may also be interested in:
 - [Tullio.jl](https://github.com/mcabbott/Tullio.jl)
 - [Gaius.jl](https://github.com/MasonProtter/Gaius.jl)
-- [PaddedMatrices.jl](https://github.com/chriselrod/PaddedMatrices.jl)


### PR DESCRIPTION
If I understand correctly, in the future, PaddedMatrices.jl will not have a matmul implementation. (And neither will StrideArrays.jl.)

So the only libraries that need to be listed are:
1. Tullio.jl
2. Gaius.jl
3. Octavian.jl
