### PR TITLE
Coverage: test with really big matrices

### DIFF
--- a/test/_matmul.jl
+++ b/test/_matmul.jl
@@ -3,99 +3,94 @@
 # `n_values`
 # `k_values`
 # `m_values`
+# `additional_n_k_m_values`
+
+# If you don't want any additional values, just set:
+# additional_n_k_m_values = []
+
+n_k_m_product = Iterators.product(n_values, k_values, m_values)
+all_n_k_m_values = Iterators.flatten([n_k_m_product, additional_n_k_m_values])
 
 @time @testset "Matrix Multiply Float32 $(testset_name_suffix)" begin
     T = Float32
-    for n ∈ n_values
-        for k ∈ k_values
-            for m ∈ m_values
-                A = rand(T, m, k)
-                B = rand(T, k, n)
-                A′ = permutedims(A)'
-                B′ = permutedims(B)'
-                AB = A * B; A′B = A′ * B; AB′ = A * B′; A′B′ = A′ * B′;
-                @info "" T n k m
-                @test @time(Octavian.matmul(A, B)) ≈ AB
-                @test @time(Octavian.matmul(A′, B)) ≈ A′B
-                @test @time(Octavian.matmul(A, B′)) ≈ AB′
-                @test @time(Octavian.matmul(A′, B′)) ≈ A′B′
-                @test @time(Octavian.matmul_serial(A, B)) ≈ AB
-                @test @time(Octavian.matmul_serial(A′, B)) ≈ A′B
-                @test @time(Octavian.matmul_serial(A, B′)) ≈ AB′
-                @test @time(Octavian.matmul_serial(A′, B′)) ≈ A′B′
-            end
-        end
+    for n_k_m ∈ all_n_k_m_values
+        n, k, m = n_k_m
+        A = rand(T, m, k)
+        B = rand(T, k, n)
+        A′ = permutedims(A)'
+        B′ = permutedims(B)'
+        AB = A * B; A′B = A′ * B; AB′ = A * B′; A′B′ = A′ * B′;
+        @info "" T n k m
+        @test @time(Octavian.matmul(A, B)) ≈ AB
+        @test @time(Octavian.matmul(A′, B)) ≈ A′B
+        @test @time(Octavian.matmul(A, B′)) ≈ AB′
+        @test @time(Octavian.matmul(A′, B′)) ≈ A′B′
+        @test @time(Octavian.matmul_serial(A, B)) ≈ AB
+        @test @time(Octavian.matmul_serial(A′, B)) ≈ A′B
+        @test @time(Octavian.matmul_serial(A, B′)) ≈ AB′
+        @test @time(Octavian.matmul_serial(A′, B′)) ≈ A′B′
     end
 end
 
 @time @testset "Matrix Multiply Float64 $(testset_name_suffix)" begin
     T = Float64
-    for n ∈ n_values
-        for k ∈ k_values
-            for m ∈ m_values
-                A = rand(T, m, k)
-                B = rand(T, k, n)
-                A′ = permutedims(A)'
-                B′ = permutedims(B)'
-                AB = A * B; A′B = A′ * B; AB′ = A * B′; A′B′ = A′ * B′;
-                @info "" T n k m
-                @test @time(Octavian.matmul(A, B)) ≈ AB
-                @test @time(Octavian.matmul(A′, B)) ≈ A′B
-                @test @time(Octavian.matmul(A, B′)) ≈ AB′
-                @test @time(Octavian.matmul(A′, B′)) ≈ A′B′
-                @test @time(Octavian.matmul_serial(A, B)) ≈ AB
-                @test @time(Octavian.matmul_serial(A′, B)) ≈ A′B
-                @test @time(Octavian.matmul_serial(A, B′)) ≈ AB′
-                @test @time(Octavian.matmul_serial(A′, B′)) ≈ A′B′
-            end
-        end
+    for n_k_m ∈ all_n_k_m_values
+        n, k, m = n_k_m
+        A = rand(T, m, k)
+        B = rand(T, k, n)
+        A′ = permutedims(A)'
+        B′ = permutedims(B)'
+        AB = A * B; A′B = A′ * B; AB′ = A * B′; A′B′ = A′ * B′;
+        @info "" T n k m
+        @test @time(Octavian.matmul(A, B)) ≈ AB
+        @test @time(Octavian.matmul(A′, B)) ≈ A′B
+        @test @time(Octavian.matmul(A, B′)) ≈ AB′
+        @test @time(Octavian.matmul(A′, B′)) ≈ A′B′
+        @test @time(Octavian.matmul_serial(A, B)) ≈ AB
+        @test @time(Octavian.matmul_serial(A′, B)) ≈ A′B
+        @test @time(Octavian.matmul_serial(A, B′)) ≈ AB′
+        @test @time(Octavian.matmul_serial(A′, B′)) ≈ A′B′
     end
 end
 
 @time @testset "Matrix Multiply Int32 $(testset_name_suffix)" begin
     T = Int32
-    for n ∈ n_values
-        for k ∈ k_values
-            for m ∈ m_values
-                A = rand(T, m, k)
-                B = rand(T, k, n)
-                A′ = permutedims(A)'
-                B′ = permutedims(B)'
-                AB = A * B; A′B = A′ * B; AB′ = A * B′; A′B′ = A′ * B′;
-                @info "" T n k m
-                @test @time(Octavian.matmul(A, B)) == AB
-                @test @time(Octavian.matmul(A′, B)) == A′B
-                @test @time(Octavian.matmul(A, B′)) == AB′
-                @test @time(Octavian.matmul(A′, B′)) == A′B′
-                @test @time(Octavian.matmul_serial(A, B)) == AB
-                @test @time(Octavian.matmul_serial(A′, B)) == A′B
-                @test @time(Octavian.matmul_serial(A, B′)) == AB′
-                @test @time(Octavian.matmul_serial(A′, B′)) == A′B′
-            end
-        end
+    for n_k_m ∈ all_n_k_m_values
+        n, k, m = n_k_m
+        A = rand(T, m, k)
+        B = rand(T, k, n)
+        A′ = permutedims(A)'
+        B′ = permutedims(B)'
+        AB = A * B; A′B = A′ * B; AB′ = A * B′; A′B′ = A′ * B′;
+        @info "" T n k m
+        @test @time(Octavian.matmul(A, B)) == AB
+        @test @time(Octavian.matmul(A′, B)) == A′B
+        @test @time(Octavian.matmul(A, B′)) == AB′
+        @test @time(Octavian.matmul(A′, B′)) == A′B′
+        @test @time(Octavian.matmul_serial(A, B)) == AB
+        @test @time(Octavian.matmul_serial(A′, B)) == A′B
+        @test @time(Octavian.matmul_serial(A, B′)) == AB′
+        @test @time(Octavian.matmul_serial(A′, B′)) == A′B′
     end
 end
 
 @time @testset "Matrix Multiply Int64 $(testset_name_suffix)" begin
     T = Int64
-    for n ∈ n_values
-        for k ∈ k_values
-            for m ∈ m_values
-                A = rand(T, m, k)
-                B = rand(T, k, n)
-                A′ = permutedims(A)'
-                B′ = permutedims(B)'
-                AB = A * B; A′B = A′ * B; AB′ = A * B′; A′B′ = A′ * B′;
-                @info "" T n k m
-                @test @time(Octavian.matmul(A, B)) == AB
-                @test @time(Octavian.matmul(A′, B)) == A′B
-                @test @time(Octavian.matmul(A, B′)) == AB′
-                @test @time(Octavian.matmul(A′, B′)) == A′B′
-                @test @time(Octavian.matmul_serial(A, B)) == AB
-                @test @time(Octavian.matmul_serial(A′, B)) == A′B
-                @test @time(Octavian.matmul_serial(A, B′)) == AB′
-                @test @time(Octavian.matmul_serial(A′, B′)) == A′B′
-            end
-        end
+    for n_k_m ∈ all_n_k_m_values
+        n, k, m = n_k_m
+        A = rand(T, m, k)
+        B = rand(T, k, n)
+        A′ = permutedims(A)'
+        B′ = permutedims(B)'
+        AB = A * B; A′B = A′ * B; AB′ = A * B′; A′B′ = A′ * B′;
+        @info "" T n k m
+        @test @time(Octavian.matmul(A, B)) == AB
+        @test @time(Octavian.matmul(A′, B)) == A′B
+        @test @time(Octavian.matmul(A, B′)) == AB′
+        @test @time(Octavian.matmul(A′, B′)) == A′B′
+        @test @time(Octavian.matmul_serial(A, B)) == AB
+        @test @time(Octavian.matmul_serial(A′, B)) == A′B
+        @test @time(Octavian.matmul_serial(A, B′)) == AB′
+        @test @time(Octavian.matmul_serial(A′, B′)) == A′B′
     end
 end

--- a/test/matmul_coverage.jl
+++ b/test/matmul_coverage.jl
@@ -1,6 +1,10 @@
-n_values  = [10, 20, 50, 100, 150, 200]
-k_values  = [10, 20, 50, 100, 150, 200]
-m_values  = [10, 20, 50, 100, 150, 200]
+n_values  = [10, 20, 50]
+k_values  = [10, 20, 50]
+m_values  = [10, 20, 50]
+
+additional_n_k_m_values = [
+    (2000, 2000, 2000),
+]
 
 testset_name_suffix = "(coverage)"
 

--- a/test/matmul_main.jl
+++ b/test/matmul_main.jl
@@ -2,6 +2,8 @@ n_values  = [200, 300, 400]
 k_values  = [200, 300, 400]
 m_values  = [200, 300, 400]
 
+additional_n_k_m_values = []
+
 testset_name_suffix = "(main)"
 
 include("_matmul.jl")


### PR DESCRIPTION
From https://github.com/JuliaLinearAlgebra/Octavian.jl/issues/11#issuecomment-763651998:
>     2. Bigger matrices. In that file, you can see that none of the matrices were big enough to pack both `A` and `B`, so related code (i.e., `matmul_st_pack_A_and_B!`, `matmul_pack_A_and_B!`, and `sync_mul!`) weren't tested.

@chriselrod Is 2000-by-2000 big enough to hit this code path?