### PR TITLE
Codecov: Comment out the "goal" project status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,7 +3,7 @@ coverage:
     project:
       default:
         target: auto
-      goal:
-        target: "95%"
+      # minimum:
+      #   target: "95%"
       minimum:
         target: "35%"


### PR DESCRIPTION
It's confusing to have an always-failing status.

We can uncomment this once we get our code coverage to >= 95%.