### PR TITLE
Increase lower bound for W1 in tilesearch.jl.

### DIFF
--- a/benchmark/tilesearch.jl
+++ b/benchmark/tilesearch.jl
@@ -80,7 +80,7 @@ hours = 60.0*60.0; days = 24hours;
 init = [Octavian.W₁Default, Octavian.W₂Default, Octavian.R₁Default, Octavian.R₂Default]
 
 opt = Optim.optimize(
-    matmul_objective, init, ParticleSwarm(lower = [0.001, 0.01, 0.3, 0.4], upper = [0.1, 2.0, 0.9, 0.99]),
+    matmul_objective, init, ParticleSwarm(lower = [0.001, 0.01, 0.3, 0.4], upper = [0.2, 2.0, 0.9, 0.99]),
     Optim.Options(iterations = 10^6, time_limit = 8hours)
 );
 


### PR DESCRIPTION
https://github.com/JuliaLinearAlgebra/Octavian.jl/blob/d47b39fce2d0f53bf6e61a48193c190401d94715/src/global_constants.jl#L24
These parameter values were found by my Haswell laptop:
```julia
const W₁Default = 0.1 # TODO: relax bounds; this was the upper bound set for the optimizer.
const W₂Default = 0.15989396641218157
const R₁Default = 0.4203583148344484
const R₂Default = 0.6344856142604789
```
Obviously, setting the upper bound to `W₁Default` at `0.1` was too low. So I'm setting it to 0.2 here.