### PR TITLE
Put the "related packages" into a table, and clarify that Octavian is a CPU library

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Octavian"
 uuid = "6fd5a793-0b7e-452c-907f-f8bfe9c57db4"
 authors = ["Mason Protter", "Chris Elrod", "Dilum Aluthge", "contributors"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,24 @@
 [ci-julia-nightly-img]: https://github.com/JuliaLinearAlgebra/Octavian.jl/workflows/CI%20(Julia%20nightly)/badge.svg "Continuous Integration (Julia nightly)"
 [codecov-img]:          https://codecov.io/gh/JuliaLinearAlgebra/Octavian.jl/branch/master/graph/badge.svg           "Code Coverage"
 
-Octavian.jl is a multi-threaded BLAS-like library that provides pure Julia
-matrix multiplication, built on top of
+Octavian.jl
+is a multi-threaded BLAS-like library that provides pure Julia
+matrix multiplication on the CPU, built on top of
 [LoopVectorization.jl](https://github.com/chriselrod/LoopVectorization.jl).
 
 Please see the
 [Octavian documentation](https://JuliaLinearAlgebra.github.io/Octavian.jl/stable).
+
+## Related Packages
+
+| Julia Package                                                    | CPU | GPU |
+| ---------------------------------------------------------------- | --- | --- |
+| [Gaius.jl](https://github.com/MasonProtter/Gaius.jl)             | Yes | No  |
+| [GemmKernels.jl](https://github.com/JuliaGPU/GemmKernels.jl)     | No  | Yes |
+| [Octavian.jl](https://github.com/JuliaLinearAlgebra/Octavian.jl) | Yes | No  |
+| [Tullio.jl](https://github.com/mcabbott/Tullio.jl)               | Yes | Yes |
+
+In general:
+- Octavian has the fastest CPU performance.
+- GemmKernels has the fastest GPU performance.
+- Tullio is the most flexible.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,8 +4,9 @@ CurrentModule = Octavian
 
 # Octavian
 
-Octavian.jl is a multi-threaded BLAS-like library that provides pure Julia
-matrix multiplication, built on top of
+[Octavian.jl](https://github.com/JuliaLinearAlgebra/Octavian.jl)
+is a multi-threaded BLAS-like library that provides pure Julia
+matrix multiplication on the CPU, built on top of
 [LoopVectorization.jl](https://github.com/chriselrod/LoopVectorization.jl).
 
 The source code for Octavian is available in the
@@ -13,10 +14,14 @@ The source code for Octavian is available in the
 
 ## Related Packages
 
-You may also be interested in:
-1. [Tullio.jl](https://github.com/mcabbott/Tullio.jl)
-2. [Gaius.jl](https://github.com/MasonProtter/Gaius.jl)
+| Julia Package                                                    | CPU | GPU |
+| ---------------------------------------------------------------- | --- | --- |
+| [Gaius.jl](https://github.com/MasonProtter/Gaius.jl)             | Yes | No  |
+| [GemmKernels.jl](https://github.com/JuliaGPU/GemmKernels.jl)     | No  | Yes |
+| [Octavian.jl](https://github.com/JuliaLinearAlgebra/Octavian.jl) | Yes | No  |
+| [Tullio.jl](https://github.com/mcabbott/Tullio.jl)               | Yes | Yes |
 
 In general:
-- Octavian is the most performant.
+- Octavian has the fastest CPU performance.
+- GemmKernels has the fastest GPU performance.
 - Tullio is the most flexible.


### PR DESCRIPTION
This pull request does a few different things:
1. It puts the list of "related packages" into a table
2. In the table, it adds columns that show which packages work on the CPU and which work on the GPU
3. Clarify in the README and the documentation that Octavian is a CPU library