### PR TITLE
documenting behavior when used with Base.Threads

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,3 +25,9 @@ In general:
 - Octavian has the fastest CPU performance.
 - GemmKernels has the fastest GPU performance.
 - Tullio is the most flexible.
+
+!!! note
+
+    Octavian's tasks can interfere with tasks spawned by Base.Threads, resulting in much slower execution times when used together. This can be avoided by using threading utilities from [CheapThreads](https://github.com/JuliaSIMD/CheapThreads.jl) or [LoopVectorization](https://github.com/JuliaSIMD/LoopVectorization.jl/) instead. See this [Discourse post](https://discourse.julialang.org/t/odd-benchmarktools-timings-using-threads-and-octavian/59838) for more information.
+
+


### PR DESCRIPTION
Adding a note to the docs on loss of performance when Octavian is combined with Base.Threads. CheapThreads and LoopVectorization are suggested as alternatives. 