### PR TITLE
Complex Matrix Multiplication (unpacked)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
           - '1'
           - '3' # GitHub runners have 2 cores, so `NUM_CORES+1` is 3
         version:
-          - '1.5'
           - '1' # automatically expands to the latest stable 1.x release of Julia
         exclude:
           - os: macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Octavian"
 uuid = "6fd5a793-0b7e-452c-907f-f8bfe9c57db4"
 authors = ["Mason Protter", "Chris Elrod", "Dilum Aluthge", "contributors"]
-version = "0.2.15"
+version = "0.2.16"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Static = "0.2"
 StrideArraysCore = "0.1.5"
 ThreadingUtilities = "0.4"
 VectorizationBase = "0.20.5"
-julia = "1.5"
+julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -12,12 +12,12 @@ ThreadingUtilities = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
-ArrayInterface = "3"
+ArrayInterface = "3.1.14"
 LoopVectorization = "0.12"
 Static = "0.2"
 StrideArraysCore = "0.1.5"
 ThreadingUtilities = "0.4"
-VectorizationBase = "0.19,0.20"
+VectorizationBase = "0.20.5"
 julia = "1.5"
 
 [extras]

--- a/src/Octavian.jl
+++ b/src/Octavian.jl
@@ -2,6 +2,8 @@ module Octavian
 
 using VectorizationBase, ArrayInterface, LoopVectorization
 
+using LoopVectorization: PtrArray
+
 using VectorizationBase: align, AbstractStridedPointer, zstridedpointer,
     static_sizeof, lazymul, StridedPointer, gesp, pause, pick_vector_width, has_feature,
     num_cache_levels, cache_size, num_cores, num_cores, cache_inclusive, cache_linesize, ifelse

--- a/src/Octavian.jl
+++ b/src/Octavian.jl
@@ -7,7 +7,7 @@ using VectorizationBase: align, AbstractStridedPointer, zstridedpointer,
     num_cache_levels, cache_size, num_cores, num_cores, cache_inclusive, cache_linesize, ifelse
 using LoopVectorization: maybestaticsize, matmul_params, preserve_buffer, CloseOpen
 using ArrayInterface: OptionallyStaticUnitRange, size, strides, offsets, indices,
-    static_length, static_first, static_last, axes, dense_dims, stride_rank, IfElse
+    static_length, static_first, static_last, axes, dense_dims, stride_rank
     
 using Static: StaticInt, Zero, One, StaticBool, True, False, gt, eq, StaticFloat64,
     roundtostaticint, floortostaticint

--- a/src/Octavian.jl
+++ b/src/Octavian.jl
@@ -2,8 +2,6 @@ module Octavian
 
 using VectorizationBase, ArrayInterface, LoopVectorization
 
-using LoopVectorization: PtrArray
-
 using VectorizationBase: align, AbstractStridedPointer, zstridedpointer,
     static_sizeof, lazymul, StridedPointer, gesp, pause, pick_vector_width, has_feature,
     num_cache_levels, cache_size, num_cores, num_cores, cache_inclusive, cache_linesize, ifelse

--- a/src/Octavian.jl
+++ b/src/Octavian.jl
@@ -9,7 +9,7 @@ using VectorizationBase: align, AbstractStridedPointer, zstridedpointer,
     num_cache_levels, cache_size, num_cores, num_cores, cache_inclusive, cache_linesize, ifelse
 using LoopVectorization: maybestaticsize, matmul_params, preserve_buffer, CloseOpen
 using ArrayInterface: OptionallyStaticUnitRange, size, strides, offsets, indices,
-    static_length, static_first, static_last, axes, dense_dims, stride_rank
+    static_length, static_first, static_last, axes, dense_dims, stride_rank, IfElse
     
 using Static: StaticInt, Zero, One, StaticBool, True, False, gt, eq, StaticFloat64,
     roundtostaticint, floortostaticint
@@ -34,6 +34,7 @@ include("funcptrs.jl")
 include("macrokernels.jl")
 include("utils.jl")
 include("matmul.jl")
+include("complex_matmul.jl")
 
 include("init.jl") # `Octavian.__init__()` is defined in this file
 

--- a/src/complex_matmul.jl
+++ b/src/complex_matmul.jl
@@ -5,9 +5,9 @@ real_rep(a::AbstractArray{Complex{T}, N}) where {T, N} = reinterpret(reshape, T,
                          α=One(), β=Zero(), nthread::Nothing=nothing, MKN=nothing, contig_axis=nothing) where {T,U,V}
     C, A, B =  real_rep.((_C, _A, _B))
 
-    η = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
-    θ = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
-    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+    η = ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
+    θ = ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
     ηθ = η*θ
 
     @avxt for n ∈ indices((C, B), 3), m ∈ indices((C, A), 2)
@@ -27,8 +27,8 @@ end
                          α=One(), β=Zero(), nthread::Nothing=nothing, MKN=nothing, contig_axis=nothing) where {T,U,V}
     C, B = real_rep.((_C, _B))
     
-    θ = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
-    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+    θ = ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
 
     @avxt for n ∈ indices((C, B), 3), m ∈ indices((C, A), (2, 1))
         Cmn_re = zero(T)
@@ -47,8 +47,8 @@ end
                          α=One(), β=Zero(), nthread::Nothing=nothing, MKN=nothing, contig_axis=nothing) where {T,U,V}
     C, A = real_rep.((_C, _A))
 
-    η = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
-    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+    η = ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
     
     @avxt for n ∈ indices((C, B), (3, 2)), m ∈ indices((C, A), 2)
         Cmn_re = zero(T)
@@ -71,9 +71,9 @@ end
                          α=One(), β=Zero(), MKN=nothing, contig_axis=nothing) where {T,U,V}
     C, A, B = real_rep.((_C, _A, _B))
 
-    η = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
-    θ = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
-    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+    η = ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
+    θ = ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
     ηθ = η*θ
     @avxt for n ∈ indices((C, B), 3), m ∈ indices((C, A), 2)
         Cmn_re = zero(T)
@@ -92,8 +92,8 @@ end
                          α=One(), β=Zero(), MKN=nothing, contig_axis=nothing) where {T,U,V}
     C, B = real_rep.((_C, _B))
 
-    θ = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
-    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+    θ = ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
     
     @avx for n ∈ indices((C, B), 3), m ∈ indices((C, A), (2, 1))
         Cmn_re = zero(T)
@@ -112,8 +112,8 @@ end
                          α=One(), β=Zero(), MKN=nothing, contig_axis=nothing) where {T,U,V}
     C, A = real_rep.((_C, _A))
 
-    η = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
-    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+    η = ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
     
     @avx for n ∈ indices((C, B), (3, 2)), m ∈ indices((C, A), 2)
         Cmn_re = zero(T)

--- a/src/complex_matmul.jl
+++ b/src/complex_matmul.jl
@@ -1,0 +1,129 @@
+real_rep(a::AbstractArray{Complex{T}, N}) where {T, N} = reinterpret(reshape, T, a)
+#PtrArray(Ptr{T}(pointer(a)), (StaticInt(2), size(a)...))
+
+@inline function _matmul!(_C::AbstractMatrix{Complex{T}}, _A::AbstractMatrix{Complex{U}}, _B::AbstractMatrix{Complex{V}},
+                         α=One(), β=Zero(), nthread::Nothing=nothing, MKN=nothing, contig_axis=nothing) where {T,U,V}
+    C, A, B =  real_rep.((_C, _A, _B))
+
+    η = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
+    θ = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+    ηθ = η*θ
+
+    @avxt for n ∈ indices((C, B), 3), m ∈ indices((C, A), 2)
+        Cmn_re = zero(T)
+        Cmn_im = zero(T)
+        for k ∈ indices((A, B), (3, 2))
+            Cmn_re +=     A[1, m, k] * B[1, k, n] - ηθ * A[2, m, k] * B[2, k, n]
+            Cmn_im += θ * A[1, m, k] * B[2, k, n] +  η * A[2, m, k] * B[1, k, n]
+        end
+        C[1,m,n] = (real(α) * Cmn_re -ᶻ imag(α) * Cmn_im) + (real(β) * C[1,m,n] -ᶻ imag(β) * C[2,m,n])
+        C[2,m,n] = (imag(α) * Cmn_re +ᶻ real(α) * Cmn_im) + (imag(β) * C[1,m,n] +ᶻ real(β) * C[2,m,n])
+    end
+    _C
+end
+
+@inline function _matmul!(_C::AbstractMatrix{Complex{T}}, A::AbstractMatrix{U}, _B::AbstractMatrix{Complex{V}},
+                         α=One(), β=Zero(), nthread::Nothing=nothing, MKN=nothing, contig_axis=nothing) where {T,U,V}
+    C, B = real_rep.((_C, _B))
+    
+    θ = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+
+    @avxt for n ∈ indices((C, B), 3), m ∈ indices((C, A), (2, 1))
+        Cmn_re = zero(T)
+        Cmn_im = zero(T)
+        for k ∈ indices((A, B), (2, 2))
+            Cmn_re +=     A[m, k] * B[1, k, n]
+            Cmn_im += θ * A[m, k] * B[2, k, n]
+        end
+        C[1,m,n] = (real(α) * Cmn_re -ᶻ imag(α) * Cmn_im) + (real(β) * C[1,m,n] -ᶻ imag(β) * C[2,m,n])
+        C[2,m,n] = (imag(α) * Cmn_re +ᶻ real(α) * Cmn_im) + (imag(β) * C[1,m,n] +ᶻ real(β) * C[2,m,n])
+    end
+    _C
+end
+
+@inline function _matmul!(_C::AbstractMatrix{Complex{T}}, _A::AbstractMatrix{Complex{U}}, B::AbstractMatrix{V},
+                         α=One(), β=Zero(), nthread::Nothing=nothing, MKN=nothing, contig_axis=nothing) where {T,U,V}
+    C, A = real_rep.((_C, _A))
+
+    η = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+    
+    @avxt for n ∈ indices((C, B), (3, 2)), m ∈ indices((C, A), 2)
+        Cmn_re = zero(T)
+        Cmn_im = zero(T)
+        for k ∈ indices((A, B), (3, 1))
+            Cmn_re +=     A[1, m, k] * B[k, n]
+            Cmn_im += η * A[2, m, k] * B[k, n]
+        end
+        C[1,m,n] = (real(α) * Cmn_re -ᶻ imag(α) * Cmn_im) + (real(β) * C[1,m,n] -ᶻ imag(β) * C[2,m,n])
+        C[2,m,n] = (imag(α) * Cmn_re +ᶻ real(α) * Cmn_im) + (imag(β) * C[1,m,n] +ᶻ real(β) * C[2,m,n])
+    end
+    _C
+end
+
+
+
+
+
+@inline function _matmul_serial!(_C::AbstractMatrix{Complex{T}}, _A::AbstractMatrix{Complex{U}}, _B::AbstractMatrix{Complex{V}},
+                         α=One(), β=Zero(), MKN=nothing, contig_axis=nothing) where {T,U,V}
+    C, A, B = real_rep.((_C, _A, _B))
+
+    η = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
+    θ = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+    ηθ = η*θ
+    @avxt for n ∈ indices((C, B), 3), m ∈ indices((C, A), 2)
+        Cmn_re = zero(T)
+        Cmn_im = zero(T)
+        for k ∈ indices((A, B), (3, 2))
+            Cmn_re +=     A[1, m, k] * B[1, k, n] - ηθ * A[2, m, k] * B[2, k, n]
+            Cmn_im += θ * A[1, m, k] * B[2, k, n] +  η * A[2, m, k] * B[1, k, n]
+        end
+        C[1,m,n] = (real(α) * Cmn_re -ᶻ imag(α) * Cmn_im) + (real(β) * C[1,m,n] -ᶻ imag(β) * C[2,m,n])
+        C[2,m,n] = (imag(α) * Cmn_re +ᶻ real(α) * Cmn_im) + (imag(β) * C[1,m,n] +ᶻ real(β) * C[2,m,n])
+    end
+    _C
+end
+
+@inline function _matmul_serial!(_C::AbstractMatrix{Complex{T}}, A::AbstractMatrix{U}, _B::AbstractMatrix{Complex{V}},
+                         α=One(), β=Zero(), MKN=nothing, contig_axis=nothing) where {T,U,V}
+    C, B = real_rep.((_C, _B))
+
+    θ = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_B), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+    
+    @avx for n ∈ indices((C, B), 3), m ∈ indices((C, A), (2, 1))
+        Cmn_re = zero(T)
+        Cmn_im = zero(T)
+        for k ∈ indices((A, B), (2, 2))
+            Cmn_re +=     A[m, k] * B[1, k, n]
+            Cmn_im += θ * A[m, k] * B[2, k, n]
+        end
+        C[1,m,n] = (real(α) * Cmn_re -ᶻ imag(α) * Cmn_im) + (real(β) * C[1,m,n] -ᶻ imag(β) * C[2,m,n])
+        C[2,m,n] = (imag(α) * Cmn_re +ᶻ real(α) * Cmn_im) + (imag(β) * C[1,m,n] +ᶻ real(β) * C[2,m,n])
+    end
+    _C
+end
+
+@inline function _matmul_serial!(_C::AbstractMatrix{Complex{T}}, _A::AbstractMatrix{Complex{U}}, B::AbstractMatrix{V},
+                         α=One(), β=Zero(), MKN=nothing, contig_axis=nothing) where {T,U,V}
+    C, A = real_rep.((_C, _A))
+
+    η = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_A), StaticInt(-1), StaticInt(1))
+    (+ᶻ, -ᶻ) = IfElse.ifelse(ArrayInterface.is_lazy_conjugate(_C), (-, +), (+, -))
+    
+    @avx for n ∈ indices((C, B), (3, 2)), m ∈ indices((C, A), 2)
+        Cmn_re = zero(T)
+        Cmn_im = zero(T)
+        for k ∈ indices((A, B), (3, 1))
+            Cmn_re +=     A[1, m, k] * B[k, n]
+            Cmn_im += η * A[2, m, k] * B[k, n]
+        end
+        C[1,m,n] = (real(α) * Cmn_re -ᶻ imag(α) * Cmn_im) + (real(β) * C[1,m,n] -ᶻ imag(β) * C[2,m,n])
+        C[2,m,n] = (imag(α) * Cmn_re +ᶻ real(α) * Cmn_im) + (imag(β) * C[1,m,n] +ᶻ real(β) * C[2,m,n])
+    end
+    _C
+end

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -238,6 +238,60 @@ end
 end
 
 
+real_rep(a::AbstractArray{Complex{T}, N}) where {T, N} = PtrArray(Ptr{T}(pointer(a)), (StaticInt(2), size(a)...))
+@inline function _matmul!(_C::AbstractMatrix{Complex{T}}, _A::AbstractMatrix{Complex{U}}, _B::AbstractMatrix{Complex{V}},
+                         α=One(), β=Zero(), nthread::Nothing=nothing, MKN=nothing, contig_axis=nothing) where {T,U,V}
+    C, A, B = real_rep.((_C, _A, _B))
+        #reinterpret(reshape, T, _C), reinterpret(reshape, U, _A), reinterpret(reshape, V, _B)
+    @avxt for n ∈ indices((C, B), 3), m ∈ indices((C, A), 2)
+        Cmn_re = zero(T)
+        Cmn_im = zero(T)
+        for k ∈ indices((A, B), (3, 2))
+            Cmn_re += A[1, m, k] * B[1, k, n] - A[2, m, k] * B[2, k, n]
+            Cmn_im += A[1, m, k] * B[2, k, n] + A[2, m, k] * B[1, k, n]
+        end
+        C[1,m,n] = (real(α) * Cmn_re - imag(α) * Cmn_im) + (real(β) * C[1,m,n] - imag(β) * C[2,m,n])
+        C[2,m,n] = (real(α) * Cmn_im + imag(α) * Cmn_re) + (real(β) * C[2,m,n] + imag(β) * C[1,m,n])
+    end
+    _C
+end
+
+@inline function _matmul!(_C::AbstractMatrix{Complex{T}}, A::AbstractMatrix{U}, _B::AbstractMatrix{Complex{V}},
+                         α=One(), β=Zero(), nthread::Nothing=nothing, MKN=nothing, contig_axis=nothing) where {T,U,V}
+    C, B = real_rep.((_C, _B))
+    #reinterpret(reshape, T, _C),  reinterpret(reshape, V, _B)
+    @avxt for n ∈ indices((C, B), 3), m ∈ indices((C, A), (2, 1))
+        Cmn_re = zero(T)
+        Cmn_im = zero(T)
+        for k ∈ indices((A, B), (2, 2))
+            Cmn_re += A[m, k] * B[1, k, n]
+            Cmn_im += A[m, k] * B[2, k, n]
+        end
+        C[1,m,n] = (real(α) * Cmn_re - imag(α) * Cmn_im) + (real(β) * C[1,m,n] - imag(β) * C[2,m,n])
+        C[2,m,n] = (real(α) * Cmn_im + imag(α) * Cmn_re) + (real(β) * C[2,m,n] + imag(β) * C[1,m,n])
+    end
+    _C
+end
+
+@inline function _matmul!(_C::AbstractMatrix{Complex{T}}, _A::AbstractMatrix{Complex{U}}, B::AbstractMatrix{V},
+                         α=One(), β=Zero(), nthread::Nothing=nothing, MKN=nothing, contig_axis=nothing) where {T,U,V}
+    C, A = real_rep.((_C, _A))
+    #reinterpret(reshape, T, _C),  reinterpret(reshape, V, _A)
+    @avxt for n ∈ indices((C, B), (3, 2)), m ∈ indices((C, A), 2)
+        Cmn_re = zero(T)
+        Cmn_im = zero(T)
+        for k ∈ indices((A, B), (3, 1))
+            Cmn_re += A[1, m, k] * B[k, n]
+            Cmn_im += A[2, m, k] * B[k, n]
+        end
+        C[1,m,n] = (real(α) * Cmn_re - imag(α) * Cmn_im) + (real(β) * C[1,m,n] - imag(β) * C[2,m,n])
+        C[2,m,n] = (real(α) * Cmn_im + imag(α) * Cmn_re) + (real(β) * C[2,m,n] + imag(β) * C[1,m,n])
+    end
+    _C
+end
+
+
+
 @inline function dontpack(pA::AbstractStridedPointer{Ta}, M, K, ::StaticInt{mc}, ::StaticInt{kc}, ::Type{Tc}, nspawn) where {mc, kc, Tc, Ta}
     # TODO: perhaps consider K vs kc by themselves?
     (contiguousstride1(pA) && ((M * K) ≤ (mc * kc) * nspawn >>> 1))

--- a/test/_matmul.jl
+++ b/test/_matmul.jl
@@ -3,39 +3,49 @@
 # `n_values`
 # `k_values`
 # `m_values`
+for T ∈ (ComplexF32, ComplexF64, Complex{Int}, Complex{Int32})
+    @time @testset "Matrix Multiply $T $(testset_name_suffix)" begin
+        for n ∈ n_values
+            for k ∈ k_values
+                for m ∈ m_values
+                    A = rand(T, m, k)
+                    B = rand(T, k, n)
 
-@time @testset "Matrix Multiply Float32 $(testset_name_suffix)" begin
-    T = Float32
-    for n ∈ n_values
-        for k ∈ k_values
-            for m ∈ m_values
-                A = rand(T, m, k)
-                B = rand(T, k, n)
-                A′ = permutedims(A)'
-                B′ = permutedims(B)'
-                AB = A * B;
-                @info "" T n k m
-                @test @time(Octavian.matmul(A, B)) ≈ AB
-                @test @time(Octavian.matmul(A′, B)) ≈ AB
-                @test @time(Octavian.matmul(A, B′)) ≈ AB
-                @test @time(Octavian.matmul(A′, B′)) ≈ AB
-                @test @time(Octavian.matmul_serial(A, B)) ≈ AB
-                @test @time(Octavian.matmul_serial(A′, B)) ≈ AB
-                @test @time(Octavian.matmul_serial(A, B′)) ≈ AB
-                @test @time(Octavian.matmul_serial(A′, B′)) ≈ AB
+                    Are = real.(A)
+                    Bre = real.(B)
+                    
+                    A′ = permutedims(A)'
+                    B′ = permutedims(B)'
+                    AB = A * B;
+                    A′B = A′*B
+                    AB′ = A*B′
+                    A′B′= A′*B′
+
+                    AreB = Are*B
+                    ABre = A*Bre
+                    
+                    @info "" T n k m
+                    @test @time(Octavian.matmul(A, B)) ≈ AB
+                    @test @time(Octavian.matmul(A, Bre)) ≈ ABre
+                    @test @time(Octavian.matmul(Are, B)) ≈ AreB
+                    @test @time(Octavian.matmul(A′, B)) ≈ A′B
+                    @test @time(Octavian.matmul(A, B′)) ≈ AB′
+                    @test @time(Octavian.matmul(A′, B′)) ≈ A′B′
+
+                    
+                    @test @time(Octavian.matmul_serial(A, B)) ≈ AB
+                    @test @time(Octavian.matmul_serial(A, Bre)) ≈ ABre
+                    @test @time(Octavian.matmul_serial(Are, B)) ≈ AreB
+                    @test @time(Octavian.matmul_serial(A′, B)) ≈ A′B
+                    @test @time(Octavian.matmul_serial(A, B′)) ≈ AB′
+                    @test @time(Octavian.matmul_serial(A′, B′)) ≈ A′B′
+                    
+                    C = Matrix{T}(undef, n, m)'
+                    @test @time(Octavian.matmul!(C, A, B)) ≈ AB
+                end
             end
         end
     end
-    m = k = n = max(8Octavian.OCTAVIAN_NUM_TASKS[], 400)
-    A = rand(T, m, k);
-    B = rand(T, k, n);
-    A′ = permutedims(A)';
-    B′ = permutedims(B)';
-    AB = A * B;
-    @test matmul_pack_ab!(similar(AB), A, B) ≈ AB
-    @test matmul_pack_ab!(similar(AB), A, B′) ≈ AB
-    @test matmul_pack_ab!(similar(AB), A′, B) ≈ AB
-    @test matmul_pack_ab!(similar(AB), A′, B′) ≈ AB
 end
 
 @time @testset "Matrix Multiply Float64 $(testset_name_suffix)" begin

--- a/test/_matmul.jl
+++ b/test/_matmul.jl
@@ -87,6 +87,40 @@ end
     @test matmul_pack_ab!(similar(AB), A′, B′) ≈ AB
 end
 
+@time @testset "Matrix Multiply Float32 $(testset_name_suffix)" begin
+    T = Float32
+    for n ∈ n_values
+        for k ∈ k_values
+            for m ∈ m_values
+                A = rand(T, m, k)
+                B = rand(T, k, n)
+                A′ = permutedims(A)'
+                B′ = permutedims(B)'
+                AB = A * B;
+                @info "" T n k m
+                @test @time(Octavian.matmul(A, B)) ≈ AB
+                @test @time(Octavian.matmul(A′, B)) ≈ AB
+                @test @time(Octavian.matmul(A, B′)) ≈ AB
+                @test @time(Octavian.matmul(A′, B′)) ≈ AB
+                @test @time(Octavian.matmul_serial(A, B)) ≈ AB
+                @test @time(Octavian.matmul_serial(A′, B)) ≈ AB
+                @test @time(Octavian.matmul_serial(A, B′)) ≈ AB
+                @test @time(Octavian.matmul_serial(A′, B′)) ≈ AB
+            end
+        end
+    end
+    m = k = n = max(8Octavian.OCTAVIAN_NUM_TASKS[], 400)
+    A = rand(T, m, k);
+    B = rand(T, k, n);
+    A′ = permutedims(A)';
+    B′ = permutedims(B)';
+    AB = A * B;
+    @test matmul_pack_ab!(similar(AB), A, B) ≈ AB
+    @test matmul_pack_ab!(similar(AB), A, B′) ≈ AB
+    @test matmul_pack_ab!(similar(AB), A′, B) ≈ AB
+    @test matmul_pack_ab!(similar(AB), A′, B′) ≈ AB
+end
+
 @time @testset "Matrix Multiply Int32 $(testset_name_suffix)" begin
     T = Int32
     for n ∈ n_values

--- a/test/_matmul.jl
+++ b/test/_matmul.jl
@@ -42,6 +42,10 @@ for T ∈ (ComplexF32, ComplexF64, Complex{Int}, Complex{Int32})
                     
                     C = Matrix{T}(undef, n, m)'
                     @test @time(Octavian.matmul!(C, A, B)) ≈ AB
+
+                    C1 = rand(T, m, n)
+                    C2 = copy(C1)
+                    @test @time(Octavian.matmul!(C1, A, B, 1.0-2.0im, 3.0+4im)) ≈ Octavian.matmul!(C2, A, B, 1.0-2.0im, 3.0+4im)
                 end
             end
         end

--- a/test/_matmul.jl
+++ b/test/_matmul.jl
@@ -45,7 +45,8 @@ for T ∈ (ComplexF32, ComplexF64, Complex{Int}, Complex{Int32})
 
                     C1 = rand(T, m, n)
                     C2 = copy(C1)
-                    @test @time(Octavian.matmul!(C1, A, B, 1.0-2.0im, 3.0+4im)) ≈ Octavian.matmul!(C2, A, B, 1.0-2.0im, 3.0+4im)
+                    α, β = T(1 - 2im), T(3 + 4im)
+                    @test @time(Octavian.matmul!(C1, A, B, α, β)) ≈ Octavian.matmul!(C2, A, B, α, β)
                 end
             end
         end


### PR DESCRIPTION
Okay, this PR implements matrix multiplication with complex hardware numbers as a macrokernel, but does *not* have the packing step meaning it'll fall behind big-boy BLAS packages for large arrays. 

Important notes

* This implementation does not allow one to select a specific number of threads, it's either threaded or it's serial. 

* It is aware of `Adjoint` matrices and will work even with arrays that have a nested series of `Adjoint`s and `Transpose`s, e.g.
```julia
let n = 100, m = 101, k = 102 
    A = transpose(transpose(rand(Complex{Float64}, n, k)')')
    @show typeof(A)
    B = rand(Complex{Float64}, k, m)
    C1 = Array{ComplexF64}(undef, m, n)'
    C2 = Array{ComplexF64}(undef, n, m)

    matmul!(C1, A, B)
       mul!(C2, A, B)
    C1 ≈ C2
end

#+RESULTS:
 typeof(A) = Transpose{ComplexF64, Adjoint{ComplexF64, Transpose{ComplexF64, Adjoint{ComplexF64, Matrix{ComplexF64}}}}}
 true
```
Note that `C1` is also `Adjoint` here and that is correctly handled.

*  This implementation is able to correctly handle 5-arg mul with complex `α` and `β`.

* It's pretty damned fast on my machine compared to OpenBLAS for small arrays:
![complex](https://user-images.githubusercontent.com/29157027/118549558-e1c7d500-b718-11eb-8864-edfce2fa5a6a.png)
<details>
<summary>repro-code</summary>

```julia
using Octavian, BenchmarkTools, Plots

ns = 4:2:150
ts = map(ns) do n
    A = rand(ComplexF64, n, n)
    B = rand(ComplexF64, n, n)
    C1 = Array{ComplexF64}(undef, n, n)
    C2 = Array{ComplexF64}(undef, n, n)
    t_Octavian = @belapsed matmul!($C1, $A, $B)
    t_OpenBLAS = @belapsed    mul!($C2, $A, $B)
    @assert C1 ≈ C2
    (;t_Octavian, t_OpenBLAS)
end

let p = plot(;xlabel="N", ylabel="t (s)", yscale=:log10, legend=:right, title="Complex{Float64} NxN Matrix Multiplication")
    plot!(p, ns, map(x -> x.t_Octavian, ts); label="Octavian.jl")
    plot!(p, ns, map(x -> x.t_OpenBLAS, ts); label="OpenBLAS")
end
```

</details>

* It'd be good to get Complex arrays in [BLASBenchmarksCPU.jl](https://github.com/JuliaLinearAlgebra/BLASBenchmarksCPU.jl) once this lands.

* I wanted / needed new features (and a bugfix) from Julia 1.6, VectorizationBase.jl and ArrayInterface.jl for this, so the compat entries are going up. 
 
* For now, when VectorizationBase.jl gives us a `stridedpointed`, that pointer will *not* know about whether or not there is an `Adjoint` or other array wrapper with lazy `conj`, this means that we have to catch and handle those `conj` operations ourselves, but perhaps one day that can be a detail that VectorizationBase.jl handles. If that does happen though, it'll break this implementation so that's something to keep an eye out for.