### PR TITLE
bump compat for ArrayInterface, ThreadingUtilities, and Static

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -18,7 +18,7 @@ jobs:
       - name: "Run CompatHelper"
         run: |
           import CompatHelper
-          CompatHelper.main()
+          CompatHelper.main(; subdirs=["", "test"])
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -15,14 +15,14 @@ ThreadingUtilities = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
-ArrayInterface = "3.1.14"
+ArrayInterface = "3.1.14, 5"
 IfElse = "0.1"
 LoopVectorization = "0.12.86"
 ManualMemory = "0.1.1"
 PolyesterWeave = "0.1.1"
 Requires = "1"
-Static = "0.2, 0.3, 0.4"
-ThreadingUtilities = "0.4.6"
+Static = "0.2, 0.3, 0.4, 0.6"
+ThreadingUtilities = "0.4.6, 0.5"
 VectorizationBase = "0.21.15"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -25,17 +25,3 @@ Static = "0.2, 0.3, 0.4, 0.6"
 ThreadingUtilities = "0.4.6, 0.5"
 VectorizationBase = "0.21.15"
 julia = "1.6"
-
-[extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
-
-[targets]
-test = ["Aqua", "BenchmarkTools", "ForwardDiff", "InteractiveUtils", "LinearAlgebra", "LoopVectorization", "Random", "VectorizationBase", "Test"]

--- a/src/Octavian.jl
+++ b/src/Octavian.jl
@@ -15,7 +15,7 @@ using Static: StaticInt, Zero, One, StaticBool, True, False, gt, eq, StaticFloat
     roundtostaticint, floortostaticint
 using ManualMemory: MemoryBuffer, load, store!
 
-using ThreadingUtilities: _atomic_add!, _atomic_load, _atomic_store!, launch, wait
+using ThreadingUtilities: _atomic_add!, _atomic_load, _atomic_store!, launch, wait, SPIN
 
 export StaticInt
 export matmul!

--- a/src/funcptrs.jl
+++ b/src/funcptrs.jl
@@ -10,6 +10,7 @@ function (::LoopMulFunc{P,TC,TA,TB,Α,Β,Md,Kd,Nd})(p::Ptr{UInt}) where {P,TC,TA
   offset, K = load(p, Kd, offset)
   offset, N = load(p, Nd, offset)
   _call_loopmul!(C, A, B, α, β, M, K, N, Val{P}())
+  _atomic_store!(p, SPIN)
   nothing
 end
 @inline _call_loopmul!(C, A, B, α, β, M, K, N, ::Val{false}) = loopmul!(C, A, B, α, β, M, K, N)
@@ -39,6 +40,7 @@ function (::SyncMulFunc{TC,TA,TB,Α,Β,Md,Kd,Nd,BCP,ID,TT,W₁,W₂,R₁,R₂})(
   offset, id = load(p, ID, offset)
   offset, total_ids = load(p, TT, offset)
   sync_mul!(C, A, B, α, β, M, K, N, atomicp, bcachep, id, total_ids, StaticFloat64{W₁}(), StaticFloat64{W₂}(), StaticFloat64{R₁}(), StaticFloat64{R₂}())
+  _atomic_store!(p, SPIN)
   nothing
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,17 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
+
+[compat]
+Aqua = "0.5"
+BenchmarkTools = "1.3"
+ForwardDiff = "0.10"
+LoopVectorization = "0.12.86"
+VectorizationBase = "0.21.15"


### PR DESCRIPTION
Closes #136, closes #137, closes #138

The CI tests of the PRs linked above fail since they depend on each other to get the latest versions. This PR combines all three compat updates, so CI should hopefully run without problems (tests pass locally for me).

I also added a `test/Project.toml` to allow setting compat bounds of test dependencies and let CompatHelper track it.