### PR TITLE
Try CI codecov on nightly too, to see if codecov is faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - '3' # GitHub runners have 2 cores, so `NUM_CORES+1` is 3
         version:
           - '1' # automatically expands to the latest stable 1.x release of Julia
+          - 'nightly'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Based on https://github.com/JuliaPerf/STREAMBenchmark.jl/pull/15#issuecomment-958749496 Octavian seems to be a good test for the new path-specific code coverage tracking that's on julia nightly now (https://github.com/JuliaLang/julia/pull/44359).

Just a draft PR to see how times compare

cc. @chriselrod 