### PR TITLE
Run CI on julia nightly only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           - '1'
           - '3' # GitHub runners have 2 cores, so `NUM_CORES+1` is 3
         version:
-          - '1' # automatically expands to the latest stable 1.x release of Julia
+          - 'nightly'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Testing along side https://github.com/JuliaLinearAlgebra/Octavian.jl/pull/142 to see if codecov reports are the same as master when only julia nightly is tested