### PR TITLE
make HyperDualNumbers.jl a weak dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Octavian"
 uuid = "6fd5a793-0b7e-452c-907f-f8bfe9c57db4"
 authors = ["Chris Elrod", "Dilum Aluthge", "Mason Protter", "contributors"]
-version = "0.3.23"
+version = "0.3.24"
 
 [deps]
 CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"

--- a/Project.toml
+++ b/Project.toml
@@ -19,9 +19,11 @@ VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [weakdeps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+HyperDualNumbers = "50ceba7f-c3ee-5a84-a6e8-3ad40456ec97"
 
 [extensions]
 ForwardDiffExt = "ForwardDiff"
+HyperDualNumbersExt = "HyperDualNumbers"
 
 [compat]
 CPUSummary = "0.1.26, 0.2.1"

--- a/src/Octavian.jl
+++ b/src/Octavian.jl
@@ -65,16 +65,15 @@ include("complex_matmul.jl")
 
 include("init.jl") # `Octavian.__init__()` is defined in this file
 
-# TODO: This loads ForwardDiff unconditionally on Julia v1.6 - v1.8.
+# TODO: This loads ForwardDiff.jl and HyperDualNumbers.jl
+#       unconditionally on Julia v1.6 - v1.8.
 #       It could be reconsidered when these older versions are not supported
-#       anymore. In this case, ForwardDiff should be removed from the
-#       dependencies and treated as weak dependency.
+#       anymore. In this case, these packages should be removed from the
+#       dependencies and treated only as weak dependency.
 if !isdefined(Base, :get_extension)
   include("../ext/ForwardDiffExt.jl")
+  include("../ext/HyperDualNumbersExt.jl")
 end
-
-# TODO: confirm when we need this extension
-include("../ext/HyperDualNumbersExt.jl")
 
 @static if VERSION >= v"1.8.0-beta1"
   @setup_workload begin


### PR DESCRIPTION
#179 made HyperDualNumbers.jl a strong (?) dependency for all Julia versions. I turned it into a weak dependency (for new versions of Julia).
I also increased the version number of Octavian.jl.