### PR TITLE
No precomp

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Octavian"
 uuid = "6fd5a793-0b7e-452c-907f-f8bfe9c57db4"
 authors = ["Chris Elrod", "Dilum Aluthge", "Mason Protter", "contributors"]
-version = "0.3.24"
+version = "0.3.25"
 
 [deps]
 CPUSummary = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"

--- a/src/Octavian.jl
+++ b/src/Octavian.jl
@@ -75,28 +75,5 @@ if !isdefined(Base, :get_extension)
   include("../ext/HyperDualNumbersExt.jl")
 end
 
-@static if VERSION >= v"1.8.0-beta1"
-  @setup_workload begin
-    # Putting some things in `setup` can reduce the size of the
-    # precompile file and potentially make loading faster.
-    __init__()
-    A64 = rand(100, 100)
-    A32 = rand(Float32, 100, 100)
-
-    @compile_workload begin
-      # All calls in this block will be precompiled, regardless of whether
-      # they belong to Octavian.jl or not (on Julia 1.8 and higher).
-      matmul(A64, A64)
-      matmul(A64', A64)
-      matmul(A64, A64')
-      matmul(A64', A64')
-
-      matmul(A32, A32)
-      matmul(A32', A32)
-      matmul(A32, A32')
-      matmul(A32', A32')
-    end
-  end
-end
 
 end # module Octavian


### PR DESCRIPTION
Precompilation kills runtime performance because of Julia bugs.
Master:
```julia
julia> @benchmark matmul!($Cf64, $Af64, $Bf64)
BenchmarkTools.Trial: 3727 samples with 1 evaluation.
 Range (min … max):  258.678 μs … 279.208 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     265.012 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   265.171 μs ±   1.905 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                     ▁▂▄▄▆█▆▆▇▇▇█▇▇▃▄▃▁▁                         
  ▂▁▁▁▁▂▂▁▂▃▂▃▃▃▄▄▅▅▇████████████████████▆▆▅▄▅▄▄▄▃▃▂▂▂▂▂▂▂▂▂▂▂▂ ▅
  259 μs           Histogram: frequency by time          272 μs <

 Memory estimate: 272 bytes, allocs estimate: 17.
```
PR:
```julia
julia> @benchmark matmul!($Cf64, $Af64, $Bf64)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  23.756 μs …  43.892 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     24.462 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   24.547 μs ± 586.526 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

           ▁▃▅▆██▆▄▃▁                                           
  ▂▂▂▂▂▃▃▅▆██████████▇▅▄▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▁▁▂▁▁▁▁▁▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  23.8 μs         Histogram: frequency by time         26.7 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
@ranocha have you seen this?

This was the benchmark script I used:
```julia
julia> A = rand(-1_000:1_000, 200, 200);

julia> B = rand(-1_000:1_000, 200, 200);

julia> C = similar(A);

julia> @benchmark mul!($C, $A, $B)
BenchmarkTools.Trial: 411 samples with 1 evaluation.
 Range (min … max):  2.283 ms …  12.646 ms  ┊ GC (min … max): 0.00% … 77.02%
 Time  (median):     2.372 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.430 ms ± 515.259 μs  ┊ GC (mean ± σ):  0.98% ±  3.80%

         ██        ▁                                           
  ▅▂▁▁▁▂▃██▄▄▅▅▅▄▄▇█▅▃▄▆▄▃▂▃▁▂▁▂▁▁▂▁▂▃▁▁▁▃▁▂▂▂▃▃▃▃▂▁▂▂▁▄▅▃▁▃▂ ▃
  2.28 ms         Histogram: frequency by time        2.67 ms <

 Memory estimate: 30.77 KiB, allocs estimate: 4.

julia> @benchmark matmul!($C, $A, $B)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  90.987 μs … 118.231 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     91.633 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   92.750 μs ±   2.644 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▃▇█▅    ▂▄▃▁ ▃▆▅▁     ▁▁                                     ▂
  ████▇▃▄▆████▇████▁▃▁▆███▇▆▅▅▁▁▃▁▁▁▁▃▁▁▁▁▃▁▁▁▁▁▁▁▅▆▆▅▄▆▅▆▆▇▆▄ █
  91 μs         Histogram: log(frequency) by time       106 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> 2.369e-3 / 91.302e-6
25.946857681102276

julia> Af64 = Float64.(A); Bf64 = Float64.(B); Cf64 = similar(Af64);

julia> @benchmark mul!($Cf64, $Af64, $Bf64)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  14.808 μs … 34.542 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     15.224 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   15.367 μs ±  1.002 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

     ▄█▆▂                                                      
  ▂▃▆████▆▄▃▂▂▂▁▁▂▂▂▂▂▁▂▁▁▁▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▁▂▂▂▂ ▃
  14.8 μs         Histogram: frequency by time        19.7 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark matmul!($Cf64, $Af64, $Bf64)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  23.756 μs …  43.892 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     24.462 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   24.547 μs ± 586.526 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

           ▁▃▅▆██▆▄▃▁                                           
  ▂▂▂▂▂▃▃▅▆██████████▇▅▄▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▁▁▂▁▁▁▁▁▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  23.8 μs         Histogram: frequency by time         26.7 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> Cf64 == C
true
```